### PR TITLE
Fixed Loading Screen and Redirection Bugs

### DIFF
--- a/app/dashboard/admin/placement/new/page.js
+++ b/app/dashboard/admin/placement/new/page.js
@@ -164,8 +164,8 @@ export default function NewPlacementScreen() {
     }, [router]);
 
     const handleNewPlacement = async (e) => {
-        setIsLoading(true);
         e.preventDefault();
+        setIsLoading(true);
 
         if (userAccess === null || userAccess === undefined) {
             alertError("Session Expired", "Please login again to continue.");
@@ -178,6 +178,7 @@ export default function NewPlacementScreen() {
 
         if (!isValidInput) {
             alertError("Error", "Please enter valid data.");
+            setIsLoading(false);
             return;
         }
 
@@ -207,12 +208,11 @@ export default function NewPlacementScreen() {
             const data = await response.json();
 
             if (response.status === 200) {
-                setIsLoading(true);
                 alertSuccess("Success", "Placement added successfully.");
 
                 setTimeout(() => {
                     router.replace("/dashboard/admin");
-                }, 2000);
+                }, 1000);
             } else if (response.status === 401) {
                 secureLocalStorage.clear();
                 alertError(
@@ -224,11 +224,13 @@ export default function NewPlacementScreen() {
                 }, 3000);
             } else if (data["message"] !== undefined) {
                 alertError("Error", data["message"]);
+                setIsLoading(false);
             } else {
                 alertError(
                     "Error",
                     "Something went wrong. Please try again later.",
                 );
+                setIsLoading(false);
             }
         } catch (err) {
             console.log(err);
@@ -236,7 +238,6 @@ export default function NewPlacementScreen() {
                 "Error",
                 "Something went wrong. Please try again later.",
             );
-        } finally {
             setIsLoading(false);
         }
     };

--- a/app/dashboard/manager/page.js
+++ b/app/dashboard/manager/page.js
@@ -341,13 +341,16 @@ export default function AdminDashboard() {
                                                 {"All Students"}
                                             </button>
                                         </Link>
-                                        <button>
+                                        <Link
+                                            className="hover:cursor-pointer"
+                                            href="/dashboard/manager/student/new"
+                                        >
                                             <div className="bg-yellow-100 text-[#544a15] rounded-xl p-2 items-center align-middle flex flex-row hover:bg-opacity-80">
                                                 <span className="material-icons">
                                                     add
                                                 </span>
                                             </div>
-                                        </button>
+                                        </Link>
                                     </div>
                                 </div>
 

--- a/app/dashboard/manager/placement/new/page.js
+++ b/app/dashboard/manager/placement/new/page.js
@@ -164,8 +164,8 @@ export default function NewPlacementScreen() {
     }, [router]);
 
     const handleNewPlacement = async (e) => {
-        setIsLoading(true);
         e.preventDefault();
+        setIsLoading(true);
 
         if (userAccess === null || userAccess === undefined) {
             alertError("Session Expired", "Please login again to continue.");
@@ -178,6 +178,7 @@ export default function NewPlacementScreen() {
 
         if (!isValidInput) {
             alertError("Error", "Please enter valid data.");
+            setIsLoading(false);
             return;
         }
 
@@ -207,12 +208,11 @@ export default function NewPlacementScreen() {
             const data = await response.json();
 
             if (response.status === 200) {
-                setIsLoading(true);
                 alertSuccess("Success", "Placement added successfully.");
 
                 setTimeout(() => {
                     router.replace("/dashboard/manager");
-                }, 2000);
+                }, 1000);
             } else if (response.status === 401) {
                 secureLocalStorage.clear();
                 alertError(
@@ -224,11 +224,13 @@ export default function NewPlacementScreen() {
                 }, 3000);
             } else if (data["message"] !== undefined) {
                 alertError("Error", data["message"]);
+                setIsLoading(false);
             } else {
                 alertError(
                     "Error",
                     "Something went wrong. Please try again later.",
                 );
+                setIsLoading(false);
             }
         } catch (err) {
             console.log(err);
@@ -236,7 +238,6 @@ export default function NewPlacementScreen() {
                 "Error",
                 "Something went wrong. Please try again later.",
             );
-        } finally {
             setIsLoading(false);
         }
     };

--- a/app/dashboard/manager/student/new/page.js
+++ b/app/dashboard/manager/student/new/page.js
@@ -224,7 +224,7 @@ export default function RegisterStudent() {
                     <div className="flex flex-1 justify-end space-x-1">
                         <Link
                             replace={true}
-                            href={"dashboard/manager/student"}
+                            href={"/dashboard/manager/student"}
                             className="bg-[#000000] text-[#ffffff] rounded-xl p-2 items-center align-middle flex flex-row hover:bg-[#3b3b3b] "
                         >
                             {"All Students"}

--- a/app/dashboard/student/editData/page.js
+++ b/app/dashboard/student/editData/page.js
@@ -277,7 +277,7 @@ export default function HandleEditData() {
                         href={"/dashboard/student"}
                         className="bg-[#000000] text-[#ffffff] rounded-xl p-2 items-center align-middle flex flex-row hover:bg-opacity-80 cursor-pointer"
                     >
-                        <span className="material-icons">person</span>
+                        <span className="material-icons">home</span>
                     </Link>
                 </nav>
             </header>

--- a/app/dashboard/student/editPlacement/[placementID]/page.js
+++ b/app/dashboard/student/editPlacement/[placementID]/page.js
@@ -239,8 +239,8 @@ export default function NewPlacementScreen() {
     }, [router]);
 
     const handleEditPlacement = async (e) => {
-        setIsLoading(true);
         e.preventDefault();
+        setIsLoading(true);
 
         if (userAccess === null || userAccess === undefined) {
             alertError("Session Expired", "Please login again to continue.");
@@ -253,6 +253,7 @@ export default function NewPlacementScreen() {
 
         if (!isValidInput) {
             alertError("Error", "Please enter valid data.");
+            setIsLoading(false);
             return;
         }
 
@@ -283,7 +284,6 @@ export default function NewPlacementScreen() {
             const data = await response.json();
 
             if (response.status === 200) {
-                setIsLoading(true);
                 alertSuccess(
                     "Success",
                     "Placement Details Edited successfully.",
@@ -306,7 +306,7 @@ export default function NewPlacementScreen() {
 
                 setTimeout(() => {
                     router.replace("/dashboard/student");
-                }, 2000);
+                }, 1000);
             } else if (response.status === 401) {
                 secureLocalStorage.clear();
                 alertError(
@@ -318,11 +318,13 @@ export default function NewPlacementScreen() {
                 }, 3000);
             } else if (data["message"] !== undefined) {
                 alertError("Error", data["message"]);
+                setIsLoading(false);
             } else {
                 alertError(
                     "Error",
                     "Something went wrong. Please try again later.",
                 );
+                setIsLoading(false);
             }
         } catch (err) {
             console.log(err);
@@ -330,7 +332,6 @@ export default function NewPlacementScreen() {
                 "Error",
                 "Something went wrong. Please try again later.",
             );
-        } finally {
             setIsLoading(false);
         }
     };

--- a/app/dashboard/student/newPlacement/page.js
+++ b/app/dashboard/student/newPlacement/page.js
@@ -161,8 +161,8 @@ export default function NewPlacementScreen() {
     }, [router]);
 
     const handleNewPlacement = async (e) => {
-        setIsLoading(true);
         e.preventDefault();
+        setIsLoading(true);
 
         if (userAccess === null || userAccess === undefined) {
             alertError("Session Expired", "Please login again to continue.");
@@ -175,6 +175,7 @@ export default function NewPlacementScreen() {
 
         if (!isValidInput) {
             alertError("Error", "Please enter valid data.");
+            setIsLoading(false);
             return;
         }
 
@@ -203,12 +204,11 @@ export default function NewPlacementScreen() {
             const data = await response.json();
 
             if (response.status === 200) {
-                setIsLoading(true);
                 alertSuccess("Success", "Placement added successfully.");
 
                 setTimeout(() => {
                     router.replace("/dashboard/student");
-                }, 2000);
+                }, 1000);
             } else if (response.status === 401) {
                 secureLocalStorage.clear();
                 alertError(
@@ -220,11 +220,13 @@ export default function NewPlacementScreen() {
                 }, 3000);
             } else if (data["message"] !== undefined) {
                 alertError("Error", data["message"]);
+                setIsLoading(false);
             } else {
                 alertError(
                     "Error",
                     "Something went wrong. Please try again later.",
                 );
+                setIsLoading(false);
             }
         } catch (err) {
             console.log(err);
@@ -232,7 +234,6 @@ export default function NewPlacementScreen() {
                 "Error",
                 "Something went wrong. Please try again later.",
             );
-        } finally {
             setIsLoading(false);
         }
     };


### PR DESCRIPTION
This PR solves #7 

The following changes were made:

1. Loading Screen Bug was fixed in Student Section (New & Edit Placement Pages) and Admin & Manager Sections (New Placement Page) 

      > When clicking the Add Placement Button the page redirected to a reset form, showed success toast and then redirected to dashboard. Now after the fix, it redirects to loading screen, shows the toast and then finally redirects to the dashboard.

3. Icon for redirection to Dashboard in Student/editData was changed to `home` instead of `person`
4. New Student Button in Manager section had no link attached (dummy button) - Linked it to new student page
5. Corrected link to redirect to All Students in Manager/newStudent

https://github.com/user-attachments/assets/ca1d7cfd-8141-40a3-9425-3769840e43a7

@Ashrockzzz2003 Please review it and let me know if I have to make any more changes. Thank You!