### PR TITLE
Add Nagercoil (NC) campus support

### DIFF
--- a/util/config.js
+++ b/util/config.js
@@ -15,6 +15,8 @@ const departements = [
 const schools = [
     "EN", // School of Engineering
     "SC", // School of Computing
+    "AI", // School of Artifical Intelligence
+    // Add more schools if needed
 ];
 
 // List of campuses
@@ -22,11 +24,14 @@ const campuses = [
     "CB", // Coimbatore
     "BL", // Bangalore
     "NC", //Nagercoil
+    // Add more campuses as needed
 ];
 
 const campusNames = {
     CB: "Coimbatore",
     BL: "Bangalore",
+    NC: "Nagercoil",
+    //Add more campuses as needed 
 };
 
 // Sub Regex's

--- a/util/config.js
+++ b/util/config.js
@@ -21,6 +21,7 @@ const schools = [
 const campuses = [
     "CB", // Coimbatore
     "BL", // Bangalore
+    "NC", //Nagercoil
 ];
 
 const campusNames = {


### PR DESCRIPTION
This change allows students from the Nagercoil campus to register using their own domain ID (NC).

Updated file: [util/config.js](https://github.com/Ashrockzzz2003/placement_tracker_web/blob/v2/util/config.js)

Related to: #42 

Note: I made the necessary server side adjustments locally as well to handle the new domain check.
Please let me know if you’d like me to open a separate PR for the server repo too!

<img width="1919" height="936" alt="Screenshot 2025-07-29 001800" src="https://github.com/user-attachments/assets/0d0fa7fd-70b6-4a09-9e76-57dc961345ef" />
