### PR TITLE
Add campus filter to student pages

### DIFF
--- a/app/dashboard/admin/student/page.js
+++ b/app/dashboard/admin/student/page.js
@@ -19,6 +19,7 @@ import { MultiSelect } from "primereact/multiselect";
 import Searchbar from "@/util/SearchBar";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment } from "react";
+import { campusNames, campuses } from "@/util/config";
 
 export default function AllPlacedStudentsScreen() {
     const [allPlacedStudentData, setAllPlacedStudentData] = useState([]);
@@ -28,6 +29,10 @@ export default function AllPlacedStudentsScreen() {
     const [_userAccess, setUserAccess] = useState("");
     const [sections, setSections] = useState();
     const [companyList, setCompanyList] = useState([]);
+    const campusList = campuses.map((campus) => ({
+        id: campus,
+        campus: campusNames[campus],
+    }));
 
     const [minCTC, setMinCTC] = useState(0);
     const [maxCTC, setMaxCTC] = useState(0);
@@ -263,6 +268,7 @@ export default function AllPlacedStudentsScreen() {
     const [searchText, setSearchText] = useState("");
     const [selectedSections, setSelectedSections] = useState(null);
     const [selectedCompanies, setSelectedCompanies] = useState(null);
+    const [selectedCampuses, setSelectedCampuses] = useState(null);
 
     const isHigherStudiesOptions = ["Higher Studies", "Not Higher Studies"];
     const [isHigherStudiesValue, setIsHigherStudiesValue] = useState("");
@@ -317,6 +323,13 @@ export default function AllPlacedStudentsScreen() {
                                     placement["companyId"],
                                 );
                             })) &&
+                        (selectedCampuses === null ||
+                            selectedCampuses.length === 0 ||
+                            selectedCampuses.some((campus) => {
+                                return student["studentRollNo"]
+                                    .toUpperCase()
+                                    .startsWith(campus);
+                            })) &&
                         (isHigherStudies === null ||
                             isHigherStudies === "" ||
                             student["isHigherStudies"] === isHigherStudies) &&
@@ -356,6 +369,7 @@ export default function AllPlacedStudentsScreen() {
         searchText,
         selectedSections,
         selectedCompanies,
+        selectedCampuses,
         isHigherStudies,
         isIntern,
         isPPO,
@@ -632,6 +646,7 @@ export default function AllPlacedStudentsScreen() {
                         setSearchText("");
                         setSelectedSections(null);
                         setSelectedCompanies(null);
+                        setSelectedCampuses(null);
                         setIsHigherStudiesValue("");
                         setIsHigherStudies(null);
                         setIsInternValue("");
@@ -827,6 +842,25 @@ export default function AllPlacedStudentsScreen() {
                                         display="chip"
                                         showClear={true}
                                         placeholder="Select Companies"
+                                        maxSelectedLabels={2}
+                                        className="w-full md:w-20rem"
+                                    />
+                                </div>
+
+                                <div className="border-bGray p-4 xl:border-b-0 xl:border-r">
+                                    <MultiSelect
+                                        value={selectedCampuses}
+                                        onChange={(e) => {
+                                            setSelectedCampuses(e.value);
+                                        }}
+                                        options={campusList}
+                                        filter
+                                        filterPlaceholder="Enter Campus Name"
+                                        optionLabel="campus"
+                                        optionValue="id"
+                                        display="chip"
+                                        showClear={true}
+                                        placeholder="Select Campuses"
                                         maxSelectedLabels={2}
                                         className="w-full md:w-20rem"
                                     />

--- a/app/dashboard/manager/student/page.js
+++ b/app/dashboard/manager/student/page.js
@@ -19,6 +19,7 @@ import { MultiSelect } from "primereact/multiselect";
 import Searchbar from "@/util/SearchBar";
 import { Dialog, Transition } from "@headlessui/react";
 import { Fragment } from "react";
+import { campusNames, campuses } from "@/util/config";
 
 export default function AllPlacedStudentsScreen() {
     const [allPlacedStudentData, setAllPlacedStudentData] = useState([]);
@@ -28,6 +29,10 @@ export default function AllPlacedStudentsScreen() {
     const [_userAccess, setUserAccess] = useState("");
     const [sections, setSections] = useState();
     const [companyList, setCompanyList] = useState([]);
+    const campusList = campuses.map((campus) => ({
+        id: campus,
+        campus: campusNames[campus],
+    }));
 
     const [minCTC, setMinCTC] = useState(0);
     const [maxCTC, setMaxCTC] = useState(0);
@@ -263,6 +268,7 @@ export default function AllPlacedStudentsScreen() {
     const [searchText, setSearchText] = useState("");
     const [selectedSections, setSelectedSections] = useState(null);
     const [selectedCompanies, setSelectedCompanies] = useState(null);
+    const [selectedCampuses, setSelectedCampuses] = useState(null);
 
     const isHigherStudiesOptions = ["Higher Studies", "Not Higher Studies"];
     const [isHigherStudiesValue, setIsHigherStudiesValue] = useState("");
@@ -317,6 +323,13 @@ export default function AllPlacedStudentsScreen() {
                                     placement["companyId"],
                                 );
                             })) &&
+                        (selectedCampuses === null ||
+                            selectedCampuses.length === 0 ||
+                            selectedCampuses.some((campus) => {
+                                return student["studentRollNo"]
+                                    .toUpperCase()
+                                    .startsWith(campus);
+                            })) &&
                         (isHigherStudies === null ||
                             isHigherStudies === "" ||
                             student["isHigherStudies"] === isHigherStudies) &&
@@ -356,6 +369,7 @@ export default function AllPlacedStudentsScreen() {
         searchText,
         selectedSections,
         selectedCompanies,
+        selectedCampuses,
         isHigherStudies,
         isIntern,
         isPPO,
@@ -631,6 +645,7 @@ export default function AllPlacedStudentsScreen() {
                         setSearchText("");
                         setSelectedSections(null);
                         setSelectedCompanies(null);
+                        setSelectedCampuses(null);
                         setIsHigherStudiesValue("");
                         setIsHigherStudies(null);
                         setIsInternValue("");
@@ -826,6 +841,25 @@ export default function AllPlacedStudentsScreen() {
                                         display="chip"
                                         showClear={true}
                                         placeholder="Select Companies"
+                                        maxSelectedLabels={2}
+                                        className="w-full md:w-20rem"
+                                    />
+                                </div>
+
+                                <div className="border-bGray p-4 xl:border-b-0 xl:border-r">
+                                    <MultiSelect
+                                        value={selectedCampuses}
+                                        onChange={(e) => {
+                                            setSelectedCampuses(e.value);
+                                        }}
+                                        options={campusList}
+                                        filter
+                                        filterPlaceholder="Enter Campus Name"
+                                        optionLabel="campus"
+                                        optionValue="id"
+                                        display="chip"
+                                        showClear={true}
+                                        placeholder="Select Campuses"
                                         maxSelectedLabels={2}
                                         className="w-full md:w-20rem"
                                     />


### PR DESCRIPTION
Closes #22.

## Summary
- Added the shared campus options from `util/config` to the admin student page.
- Added the same campus filter to the manager student page.
- Filters students by roll number prefix so campuses like `CB`, `BL`, and `NC` can be selected just like the existing placement pages.
- Resets the campus filter when switching batches.

## Verification
- `node --check app/dashboard/admin/student/page.js`
- `node --check app/dashboard/manager/student/page.js`
- `git diff --check`
- `node node_modules/next/dist/bin/next build`

Note: `next build` compiled and generated all pages successfully. It still prints the repository's existing ESLint circular config warning from `.eslintrc.json`, unrelated to this change.