### PR TITLE
Add campus filter to manager placements

### DIFF
--- a/app/dashboard/manager/placement/page.js
+++ b/app/dashboard/manager/placement/page.js
@@ -23,6 +23,7 @@ import { MultiSelect } from "primereact/multiselect";
 import Searchbar from "@/util/SearchBar";
 import { Dialog, Transition } from "@headlessui/react";
 import { Chart } from "primereact/chart";
+import { campusNames, campuses } from "@/util/config";
 
 export default function AllPlacedStudentsScreen() {
     const [allPlacedStudentData, setAllPlacedStudentData] = useState([]);
@@ -33,6 +34,10 @@ export default function AllPlacedStudentsScreen() {
     const [_, setUserAccess] = useState("");
     const [sections, setSections] = useState();
     const [companyList, setCompanyList] = useState([]);
+    const campusList = campuses.map((campus) => ({
+        id: campus,
+        campus: campusNames[campus],
+    }));
 
     const [companyNames, setCompanyNames] = useState([]);
     const [totalHires, setTotalHires] = useState([]);
@@ -339,6 +344,7 @@ export default function AllPlacedStudentsScreen() {
     const [searchText, setSearchText] = useState("");
     const [selectedSections, setSelectedSections] = useState(null);
     const [selectedCompanies, setSelectedCompanies] = useState(null);
+    const [selectedCampuses, setSelectedCampuses] = useState(null);
 
     const isHigherStudiesOptions = ["Higher Studies", "Not Higher Studies"];
     const [isHigherStudiesValue, setIsHigherStudiesValue] = useState("");
@@ -414,6 +420,13 @@ export default function AllPlacedStudentsScreen() {
                                     placement["companyId"],
                                 );
                             })) &&
+                        (selectedCampuses === null ||
+                            selectedCampuses.length === 0 ||
+                            selectedCampuses.some((campus) => {
+                                return student["studentRollNo"]
+                                    .toUpperCase()
+                                    .startsWith(campus);
+                            })) &&
                         (isHigherStudies === null ||
                             isHigherStudies === "" ||
                             student["isHigherStudies"] === isHigherStudies) &&
@@ -447,6 +460,7 @@ export default function AllPlacedStudentsScreen() {
         searchText,
         selectedSections,
         selectedCompanies,
+        selectedCampuses,
         isHigherStudies,
         isIntern,
         isPPO,
@@ -751,6 +765,7 @@ export default function AllPlacedStudentsScreen() {
                         setSearchText("");
                         setSelectedSections(null);
                         setSelectedCompanies(null);
+                        setSelectedCampuses(null);
                         setIsHigherStudiesValue("");
                         setIsHigherStudies(null);
                         setIsInternValue("");
@@ -929,6 +944,25 @@ export default function AllPlacedStudentsScreen() {
                                         display="chip"
                                         showClear={true}
                                         placeholder="Select Companies"
+                                        maxSelectedLabels={2}
+                                        className="w-full md:w-20rem"
+                                    />
+                                </div>
+
+                                <div className="border-bGray p-4 xl:border-b-0 xl:border-r">
+                                    <MultiSelect
+                                        value={selectedCampuses}
+                                        onChange={(e) => {
+                                            setSelectedCampuses(e.value);
+                                        }}
+                                        options={campusList}
+                                        filter
+                                        filterPlaceholder="Enter Campus Name"
+                                        optionLabel="campus"
+                                        optionValue="id"
+                                        display="chip"
+                                        showClear={true}
+                                        placeholder="Select Campuses"
                                         maxSelectedLabels={2}
                                         className="w-full md:w-20rem"
                                     />


### PR DESCRIPTION
## Summary
- Add the campus multi-select filter to the manager placements page.
- Reuse the existing campus config and roll-number prefix matching used on the student/admin views.
- Reset the campus filter when loading a different batch.

## Validation
- npm run build completed successfully and generated pages.
- npm run lint still hits the repository's existing Next/ESLint circular JSON config issue in .eslintrc.json.

Follow-up to the merged campus filter work for issue #22.